### PR TITLE
Add WebRouter and introduce state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swizzyweb/swizzy-web-service",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@swizzyweb/swizzy-web-service",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@swizzyweb/express": "^4.19.2",
@@ -20,9 +20,11 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.12.8",
+        "@types/supertest": "^6.0.2",
         "@types/tcp-port-used": "^1.0.4",
         "jest": "^29.7.0",
         "prettier": "^3.3.3",
+        "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.4.5"
       }
@@ -1061,6 +1063,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -1134,6 +1142,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1187,6 +1201,28 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/tcp-port-used": {
       "version": "1.0.4",
@@ -1292,10 +1328,22 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1725,6 +1773,27 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1768,6 +1837,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -1856,6 +1931,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1880,6 +1964,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2265,6 +2359,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2371,6 +2471,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2563,6 +2691,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -4483,6 +4620,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swizzyweb/swizzy-web-service",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Web service framework for swizzy dyn serve",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,9 +17,11 @@
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.12.8",
+    "@types/supertest": "^6.0.2",
     "@types/tcp-port-used": "^1.0.4",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.4.5"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./web-service";
 export * from "./util/logger";
+export * from "./web-router";

--- a/src/web-router.ts
+++ b/src/web-router.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+
+// See if router is a class?
+export interface IWebRouter<STATE, GLOBAL_STATE> {
+  initialize(props: IWebRouterInitProps<GLOBAL_STATE>): Promise<void>;
+  router(): any;//Router;
+  getState(): STATE;
+  /**
+   * Not sure if we should strongly type key / values
+   */
+  //setStateParam(key: any, value: any): Promise<void>;
+}
+
+export interface IWebRouterProps<STATE> {
+  state: STATE;
+}
+
+export interface IWebRouterInitProps<GLOBAL_STATE> {
+  globalState?: GLOBAL_STATE
+}
+  
+
+
+// Thinking...
+export abstract class WebRouter<STATE, GLOBAL_STATE> implements IWebRouter<STATE, GLOBAL_STATE> {
+  /**
+  * Configured in initialize.
+  */
+  actualRouter?: Router;
+  state: STATE;
+  globalState?: GLOBAL_STATE
+  constructor(props: IWebRouterProps<STATE>) {
+     this.state = props.state;
+//     this.router.bind(this);
+  }
+
+  // Should we inject state here instead?
+  // Then we can init it in the web service?
+  // Let's have two states, global and this inner state.
+  // Feel free to overide
+  async initialize(props: IWebRouterInitProps<GLOBAL_STATE>): Promise<void> {
+    this.globalState = props.globalState;
+  }
+
+  router(): Router {
+//    this.router.bind(this);
+    console.log(this);
+    console.log(this.actualRouter);
+    if (this.actualRouter) {
+
+      return this.actualRouter;
+    } else {
+      throw {name: 'RouterNotInitializedError', message: `Router is not defined, did you call initialize on this router?`};
+    }
+
+
+  }
+  
+  /*setStateParam(key: any, value: any): Promise<void> {
+    this.state[key] = value;
+  }*/
+
+  getState(): STATE {
+    return this.state;
+  }
+  
+}

--- a/src/web-service-props.ts
+++ b/src/web-service-props.ts
@@ -27,5 +27,6 @@ export interface IWebServiceProps {
   routers?: Router[];
   appDataRoot?: string;
   serviceArgs?: any;
+  state?: any;
 }
 

--- a/test/impls/test-web-router.ts
+++ b/test/impls/test-web-router.ts
@@ -1,0 +1,52 @@
+import { WebRouter, IWebRouterProps, IWebRouterInitProps } from '../../src/web-router';
+import express, {Request, Response} from 'express';
+
+
+export interface IMyFirstWebRouterState {
+  memoryDb: any;
+  currentUserName?: string;
+}
+
+export interface IMyFirstWebRouterProps extends IWebRouterProps<IMyFirstWebRouterState> {
+}
+
+export interface IMyFirstWebServiceInitProps extends IWebRouterInitProps<any> {
+
+}
+
+export class MyFirstWebRouter extends WebRouter<IMyFirstWebRouterState, any> {
+  constructor(props: IMyFirstWebRouterProps) {
+    super({...props,
+    state: {
+        ...props.state, 
+        currentUserName: 'WannaWatchMeCode'
+        }
+      });
+
+  }
+
+  async initialize(props: IMyFirstWebServiceInitProps): Promise<void> {
+    await super.initialize(props);
+    const router = express.Router();
+    const state = this.state;
+    router.get('/hello', (req: Request, res: Response) => {
+      //res.contentType('text/plain')
+      res.send({message: `Hello ${state.currentUserName}!`});
+    });
+
+    router.post('/name', (req: Request, res: Response) => {
+      const oldUserName = state.currentUserName;
+      state.currentUserName = req.body.userName;
+      res.send({message:`Username has been updated from ${oldUserName} to ${state.currentUserName}`});
+    });
+
+    router.get('/creator', (req: Request, res: Response) => {
+      res.send({message: `The creator of this app is ${this.globalState.creatorName}`,
+        createdAt: this.globalState.createdAt});
+    });
+
+    this.actualRouter = router;
+  }
+
+
+}

--- a/test/impls/web-router-web-service.ts
+++ b/test/impls/web-router-web-service.ts
@@ -1,0 +1,19 @@
+import { WebService } from '../../src/web-service';
+import { IWebServiceProps } from '../../src/web-service-props'
+import { MyFirstWebRouter } from './test-web-router';
+export interface IWebRouterWebServiceProps extends IWebServiceProps {
+  
+}
+
+export class WebRouterWebService extends WebService {
+  readonly name: string = "WebRouterWebService";
+
+  constructor(props: IWebRouterWebServiceProps) {
+    super({...props,
+      routers: [
+        new MyFirstWebRouter({state: {memoryDb: {}}})
+    ]});
+  }
+}
+
+

--- a/test/web-router.spec.ts
+++ b/test/web-router.spec.ts
@@ -1,0 +1,56 @@
+// Import the module or component to test
+import { WebRouter } from '../src/web-router';
+import { MyFirstWebRouter } from './impls/test-web-router';
+import request from 'supertest';
+import express from 'express';
+// Describe the test suite
+describe('WebRouter test', () => {
+  let app: any;
+
+
+  // Example of a unit test for a function
+  describe('MyFirstWebRouter', () => {
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json()); // Middleware to parse JSON
+  });
+    it('Should throw when router not initialized and attempt to retrieve router', async () => {
+      const router = new MyFirstWebRouter({state: {memoryDb: {}}})      
+
+    expect(router.router.bind(router)).toThrow({name: 'RouterNotInitializedError', message: `Router is not defined, did you call initialize on this router?`});
+      
+    });
+
+    it('Should return default userName', async () => {
+      const router = new MyFirstWebRouter({state: {memoryDb: {}}})      
+      await router.initialize({});
+    app.use('/api', router.router()); // Mount the router
+    const response = await request(app).get('/api/hello');
+      expect(response.body).toEqual({message: 'Hello WannaWatchMeCode!'});
+    });
+
+     it('Should update userName', async () => {
+      const router = new MyFirstWebRouter({state: {memoryDb: {}}})      
+      await router.initialize({});
+    app.use('/api', router.router()); // Mount the router
+
+      // TODO: take advantage of supertest chaining methods
+    const response = await request(app).post('/api/name').send({userName: 'Jaymoney'});
+      expect(response.body).toEqual({message:`Username has been updated from WannaWatchMeCode to Jaymoney`});
+    });
+
+     it('Should update use global state to show creator and create time', async () => {
+      const router = new MyFirstWebRouter({state: {memoryDb: {}}})
+      const createdAt = Date.now();
+      const creatorName = 'SwizzyWeb';
+      await router.initialize({globalState: {creatorName, createdAt}});
+    app.use('/api', router.router()); // Mount the router
+
+      // TODO: take advantage of supertest chaining methods
+    const response = await request(app).get('/api/creator')
+      .expect({message: `The creator of this app is ${creatorName}`,
+        createdAt});
+    });
+  });
+});

--- a/test/web-service.spec.ts
+++ b/test/web-service.spec.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "@jest/globals";
 import { DummyWebService } from "./dummy-web-service";
-
+import path from 'path';
+import request from 'supertest';
+import express from 'express';
+import { WebRouterWebService } from './impls/web-router-web-service';
 describe("webservice", () => {
+let app: any;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json()); // Middleware to parse JSON
+  });
+ 
   test("sets default app directory to root package", () => {
     const args = {
       packageName: "@swizzyweb/dummy-web-service",
@@ -14,14 +23,14 @@ describe("webservice", () => {
       //port?: number;
       //logger?: ilogger;
       //routers?: router[],
-      appDataRootPath: undefined,
+      appDataRoot: undefined,
       serviceArgs: {},
     };
 
     const webservice: any = new DummyWebService(args);
     expect(webservice.appDataPath).toBe(
-      "/home/jmoney/repos/BrowserToolkitWorkspace/SwizzyWebService/appdata/@swizzyweb/dummy-web-service",
-    );
+      path.resolve(__dirname, "../appdata/@swizzyweb/dummy-web-service")
+);
   });
   test("sets app directory to specified absolute path", () => {
     const args = {
@@ -35,7 +44,7 @@ describe("webservice", () => {
       //port?: number;
       //logger?: ilogger;
       //routers?: router[],
-      appDataRootPath: "/tmp/dynserve/",
+      appDataRoot: "/tmp/dynserve/",
       serviceArgs: {},
     };
 
@@ -56,15 +65,62 @@ describe("webservice", () => {
       //port?: number;
       //logger?: ilogger;
       //routers?: router[],
-      appDataRootPath: "dynserve/",
+      appDataRoot: "dynserve/",
       serviceArgs: {},
     };
 
     const webservice: any = new DummyWebService(args);
     expect(webservice.appDataPath).toBe(
-      "/home/jmoney/repos/BrowserToolkitWorkspace/SwizzyWebService/dynserve/appdata/@swizzyweb/dummy-web-service",
+      path.join(__dirname, "../dynserve/appdata/@swizzyweb/dummy-web-service")
     );
   });
 
+  it('Should install express router', () => {
+    const args = {
+      packageName: "@swizzyweb/dummy-web-service",
+      /**
+       * attach to existing app managed externally.
+       * the web service will not start the listener or specify port for the express app
+       * if this is specified. if specified you cannot specify the port parameter.
+       */
+      //app?: application;
+      //port?: number;
+      //logger?: ilogger;
+      //routers?: router[],
+      appDataRoot: undefined,
+      serviceArgs: {},
+    };
+
+   // const webservice: any = new DummyWebService(args);
+  });
+
+  it('Should install WebRouter', async () => {
+      const args = {
+      packageName: "@swizzyweb/dummy-web-service",
+      /**
+       * attach to existing app managed externally.
+       * the web service will not start the listener or specify port for the express app
+       * if this is specified. if specified you cannot specify the port parameter.
+       */
+      //app?: application;
+      //port?: number;
+      //logger?: ilogger;
+      //routers?: router[],
+      appDataRoot: undefined,
+      serviceArgs: {},
+      state: {
+        createdAt: Date.now(),
+        creatorName: 'Jaymoney'
+      },
+      app,
+    };
+
+    const webservice: any = new WebRouterWebService(args);
+//  try {
+    await webservice.install({});
+//    } catch(e) {
+  //    console.log(JSON.stringify(e));
+    //}
+  })
   
 });


### PR DESCRIPTION
Add WebRouter

WebRouter wraps express routers and allows for injecting global and local state.

Update WebService to support both new WebRouter's and native express Routers.

Add tests, needs more work.

Testing:

Unit tests

Build/run diff image with updated code.
* Running legacy routers
* Updating diff image to use new WebRouters and testing successfully.